### PR TITLE
fix: about ass two problem.

### DIFF
--- a/bcc2ass.py
+++ b/bcc2ass.py
@@ -22,6 +22,8 @@ def bcc2ass(bcc, output, type):
     with open(output, 'w', encoding='utf-8') as f:
         count = 1
         if type == 'ass':
+            print("[Script Info]", file=f)
+            print(file=f)
             print("[V4+ Styles]", file=f)
             print("Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding", file=f)
             location = {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0}
@@ -29,7 +31,7 @@ def bcc2ass(bcc, output, type):
             for i in bcc['body']:
                 location[i['location']] += 1
                 if location[Alignment] < location[i['location']]: Alignment = i['location']
-            print("Style: Default", "Arial", "%d" % (bcc['font_size'] * 16), color2asscolor(bcc['font_color']), "&H000000FF", color2asscolor(bcc['background_color'], int(bcc['background_alpha'] * 0xFF)), "&H00000000,0,0,0,0,100,100,0,0,1,2,2,%d,10,10,10,1" % Alignment, sep=',', file=f)
+            print("Style: Default", "Arial", "%d" % (bcc['font_size'] * 10 + 10), color2asscolor(bcc['font_color']), "&H000000FF", color2asscolor(bcc['background_color'], int(bcc['background_alpha'] * 0xFF)), "&H00000000,0,0,0,0,100,100,0,0,1,2,2,%d,10,10,10,1" % Alignment, sep=',', file=f)
             print(file=f)
             print("[Events]", file=f)
             print("Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text", file=f)


### PR DESCRIPTION
- 某些播放器如果没有加入`[Script Info]`这行则会无法正常加载该文件。（如mpv）
- 正常下载下来的bcc字体大小是0.4，而0.4*16是6.4，这显然不是正常的大小，假设字体大小在0.1~1间，那么size*10+10即可令其保持在10~20。